### PR TITLE
Add terminal Othello game with AI and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.py[cod]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
-# -
+# Othello
+
+A simple terminal-based implementation of the classic Othello/Reversi board game. The game includes:
+
+- Core board logic with move validation and disc flipping.
+- A light-weight heuristic AI opponent that prioritises strong board positions.
+- A command-line interface for human vs. human or human vs. AI matches.
+
+## Playing the game
+
+```bash
+python -m othello.cli [--ai {none,black,white}] [--randomness FLOAT]
+```
+
+Use coordinates such as `d3` or `4 5` when prompted. Enter `pass` when you have no valid moves.
+
+By default the AI controls the white pieces while you play as black. Use `--ai none` to play a two-player hot-seat match or `--ai black` to let the AI take the first turn.
+
+## Running the tests
+
+```bash
+pytest
+```

--- a/othello/__init__.py
+++ b/othello/__init__.py
@@ -1,0 +1,13 @@
+"""Simple Othello game package."""
+
+from .board import Board, BLACK, WHITE, EMPTY, opponent
+from .game import OthelloGame
+
+__all__ = [
+    "Board",
+    "BLACK",
+    "WHITE",
+    "EMPTY",
+    "opponent",
+    "OthelloGame",
+]

--- a/othello/ai.py
+++ b/othello/ai.py
@@ -1,0 +1,56 @@
+"""Simple heuristic AI for the Othello game."""
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass, field
+from typing import Optional, Tuple
+
+from .board import Board, opponent
+
+Move = Tuple[int, int]
+
+# Positional weights encourage the AI to prioritise corners and edges.
+POSITION_WEIGHTS: Tuple[Tuple[int, ...], ...] = (
+    (100, -20, 10, 5, 5, 10, -20, 100),
+    (-20, -50, -2, -2, -2, -2, -50, -20),
+    (10, -2, 5, 1, 1, 5, -2, 10),
+    (5, -2, 1, 0, 0, 1, -2, 5),
+    (5, -2, 1, 0, 0, 1, -2, 5),
+    (10, -2, 5, 1, 1, 5, -2, 10),
+    (-20, -50, -2, -2, -2, -2, -50, -20),
+    (100, -20, 10, 5, 5, 10, -20, 100),
+)
+
+
+@dataclass
+class HeuristicAI:
+    """A lightweight opponent powered by a static evaluation function."""
+
+    randomness: float = 0.0
+    rng: random.Random = field(init=False, repr=False, default_factory=random.Random)
+
+    def choose_move(self, board: Board, color: str) -> Optional[Move]:
+        moves = board.valid_moves(color)
+        if not moves:
+            return None
+
+        scored_moves = [(self._evaluate_move(board, color, move), move) for move in moves]
+        scored_moves.sort(key=lambda item: item[0], reverse=True)
+
+        if self.randomness > 0 and len(scored_moves) > 1:
+            threshold = max(0.0, min(1.0, self.randomness))
+            if self.rng.random() < threshold:
+                return self.rng.choice([move for _, move in scored_moves])
+
+        return scored_moves[0][1]
+
+    def _evaluate_move(self, board: Board, color: str, move: Move) -> float:
+        row, col = move
+        clone = board.clone()
+        flipped = clone.apply_move(row, col, color)
+        mobility = len(clone.valid_moves(color)) - len(clone.valid_moves(opponent(color)))
+        return (
+            float(POSITION_WEIGHTS[row][col])
+            + flipped * 5.0
+            + mobility * 0.5
+        )

--- a/othello/board.py
+++ b/othello/board.py
@@ -1,0 +1,147 @@
+"""Core board representation for the Othello game."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Tuple
+
+BLACK = "B"
+WHITE = "W"
+EMPTY = "."
+
+DIRECTIONS: Tuple[Tuple[int, int], ...] = (
+    (-1, -1),
+    (-1, 0),
+    (-1, 1),
+    (0, -1),
+    (0, 1),
+    (1, -1),
+    (1, 0),
+    (1, 1),
+)
+
+
+class InvalidMoveError(ValueError):
+    """Raised when a move cannot legally be played on the board."""
+
+
+@dataclass
+class Board:
+    """Representation of an 8x8 Othello board."""
+
+    size: int = 8
+
+    def __post_init__(self) -> None:
+        self._grid: List[List[str]] = [[EMPTY for _ in range(self.size)] for _ in range(self.size)]
+        self.reset()
+
+    def reset(self) -> None:
+        """Reset the board to the initial game state."""
+        for row in range(self.size):
+            for col in range(self.size):
+                self._grid[row][col] = EMPTY
+
+        middle = self.size // 2
+        self._grid[middle - 1][middle - 1] = WHITE
+        self._grid[middle][middle] = WHITE
+        self._grid[middle - 1][middle] = BLACK
+        self._grid[middle][middle - 1] = BLACK
+
+    def clone(self) -> "Board":
+        """Return a copy of the board."""
+        new_board = Board(self.size)
+        new_board._grid = [row[:] for row in self._grid]
+        return new_board
+
+    def in_bounds(self, row: int, col: int) -> bool:
+        return 0 <= row < self.size and 0 <= col < self.size
+
+    def get(self, row: int, col: int) -> str:
+        if not self.in_bounds(row, col):
+            raise IndexError("Position outside of the board")
+        return self._grid[row][col]
+
+    def _captures_from(self, row: int, col: int, color: str) -> List[Tuple[int, int]]:
+        if self._grid[row][col] != EMPTY:
+            return []
+
+        captured: List[Tuple[int, int]] = []
+        for d_row, d_col in DIRECTIONS:
+            line: List[Tuple[int, int]] = []
+            r, c = row + d_row, col + d_col
+            while self.in_bounds(r, c) and self._grid[r][c] == opponent(color):
+                line.append((r, c))
+                r += d_row
+                c += d_col
+            if line and self.in_bounds(r, c) and self._grid[r][c] == color:
+                captured.extend(line)
+        return captured
+
+    def valid_moves(self, color: str) -> List[Tuple[int, int]]:
+        """Return a list of legal moves for ``color``."""
+        moves: List[Tuple[int, int]] = []
+        for row in range(self.size):
+            for col in range(self.size):
+                if self._grid[row][col] != EMPTY:
+                    continue
+                if self._captures_from(row, col, color):
+                    moves.append((row, col))
+        return moves
+
+    def apply_move(self, row: int, col: int, color: str) -> int:
+        """Place a disc on the board and flip captured discs.
+
+        Args:
+            row: Row index of the move (0-based).
+            col: Column index of the move (0-based).
+            color: Disc colour, ``BLACK`` or ``WHITE``.
+
+        Returns:
+            The number of discs flipped by the move.
+
+        Raises:
+            InvalidMoveError: If the move is illegal.
+        """
+
+        captured = self._captures_from(row, col, color)
+        if not captured:
+            raise InvalidMoveError(f"Illegal move at ({row}, {col}) for {color}.")
+
+        self._grid[row][col] = color
+        for r, c in captured:
+            self._grid[r][c] = color
+        return len(captured)
+
+    def has_any_valid_move(self, color: str) -> bool:
+        for row in range(self.size):
+            for col in range(self.size):
+                if self._grid[row][col] == EMPTY and self._captures_from(row, col, color):
+                    return True
+        return False
+
+    def is_full(self) -> bool:
+        return all(cell != EMPTY for row in self._grid for cell in row)
+
+    def score(self) -> Dict[str, int]:
+        counts = {BLACK: 0, WHITE: 0, EMPTY: 0}
+        for row in self._grid:
+            for cell in row:
+                counts[cell] += 1
+        return counts
+
+    def to_lines(self) -> List[str]:
+        header = "  " + " ".join(chr(ord("a") + i) for i in range(self.size))
+        lines = [header]
+        for idx, row in enumerate(self._grid, 1):
+            lines.append(f"{idx} " + " ".join(row))
+        return lines
+
+    def __str__(self) -> str:  # pragma: no cover - trivial formatting
+        return "\n".join(self.to_lines())
+
+
+def opponent(color: str) -> str:
+    if color == BLACK:
+        return WHITE
+    if color == WHITE:
+        return BLACK
+    raise ValueError(f"Unknown disc colour: {color}")

--- a/othello/cli.py
+++ b/othello/cli.py
@@ -1,0 +1,135 @@
+"""Command line interface for playing Othello."""
+from __future__ import annotations
+
+import argparse
+from typing import Iterable, List, Optional
+
+from .ai import HeuristicAI
+from .board import BLACK, WHITE, Board
+from .game import OthelloGame, format_move
+
+Move = tuple[int, int]
+
+
+def parse_move(text: str) -> Optional[Move]:
+    cleaned = text.strip().lower()
+    if cleaned in {"pass", "p"}:
+        return None
+
+    if len(cleaned) == 2 and cleaned[0].isalpha() and cleaned[1].isdigit():
+        col = ord(cleaned[0]) - ord("a")
+        row = int(cleaned[1]) - 1
+        if 0 <= row < 8 and 0 <= col < 8:
+            return (row, col)
+
+    if "," in cleaned:
+        parts = cleaned.split(",")
+    else:
+        parts = cleaned.split()
+
+    if len(parts) == 2 and all(part.isdigit() for part in parts):
+        row, col = (int(parts[0]) - 1, int(parts[1]) - 1)
+        if 0 <= row < 8 and 0 <= col < 8:
+            return (row, col)
+
+    raise ValueError("Invalid move format. Use e.g. 'd3' or '4 5'.")
+
+
+def colour_name(colour: str) -> str:
+    return "Black" if colour == BLACK else "White"
+
+
+def display_board(board: Board) -> None:
+    print()
+    for line in board.to_lines():
+        print(line)
+    scores = board.score()
+    print(f"Black: {scores[BLACK]}    White: {scores[WHITE]}")
+
+
+def human_turn(colour: str, moves: Iterable[Move]) -> Optional[Move]:
+    move_list = sorted(moves)
+    readable_moves = ", ".join(format_move(move) for move in move_list)
+    prompt = f"{colour_name(colour)} to move. Enter a move ({readable_moves}) or 'pass': "
+    while True:
+        try:
+            raw = input(prompt)
+        except EOFError:  # pragma: no cover - interactive guard
+            raise SystemExit(0)
+        try:
+            move = parse_move(raw)
+        except ValueError as exc:
+            print(exc)
+            continue
+
+        if move is None:
+            if move_list:
+                print("You still have legal moves and cannot pass.")
+                continue
+            return None
+        if move not in move_list:
+            print("That move is not legal. Try again.")
+            continue
+        return move
+
+
+def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Play a game of Othello in the terminal.")
+    parser.add_argument(
+        "--ai",
+        choices=["none", "black", "white"],
+        default="white",
+        help="Choose which side is played by the computer.",
+    )
+    parser.add_argument(
+        "--randomness",
+        type=float,
+        default=0.2,
+        help="Probability of the AI selecting a sub-optimal move.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[List[str]] = None) -> None:
+    args = parse_args(argv)
+
+    ai = HeuristicAI(randomness=args.randomness)
+    ai_sides = {
+        "black": {BLACK},
+        "white": {WHITE},
+        "none": set(),
+    }[args.ai]
+
+    game = OthelloGame()
+    print("Welcome to Othello! Coordinates are entered as column+row (e.g. d3).")
+
+    while not game.finished:
+        display_board(game.board)
+        colour = game.current_player
+        moves = game.valid_moves()
+
+        if not moves:
+            print(f"{colour_name(colour)} has no legal moves and must pass.")
+            game.play_turn(None)
+            continue
+
+        if colour in ai_sides:
+            move = ai.choose_move(game.board, colour)
+            if move is None:
+                print(f"{colour_name(colour)} cannot move and passes.")
+            else:
+                print(f"{colour_name(colour)} (AI) plays {format_move(move)}")
+        else:
+            move = human_turn(colour, moves)
+        game.play_turn(move)
+
+        last = game.history[-1]
+        if last.position is None and last.player != game.current_player:
+            print(f"{colour_name(last.player)} has no moves and passes.")
+
+    display_board(game.board)
+    print(game.game_result())
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    main()

--- a/othello/game.py
+++ b/othello/game.py
@@ -1,0 +1,103 @@
+"""High level game orchestration for Othello."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Optional, Tuple
+
+from .board import BLACK, WHITE, Board, InvalidMoveError, opponent
+
+Move = Tuple[int, int]
+
+
+def _winner_from_scores(scores: dict[str, int]) -> Optional[str]:
+    if scores[BLACK] > scores[WHITE]:
+        return BLACK
+    if scores[WHITE] > scores[BLACK]:
+        return WHITE
+    return None
+
+
+@dataclass
+class MoveRecord:
+    """A single move performed during the game."""
+
+    player: str
+    position: Optional[Move]
+    flipped: int = 0
+
+
+@dataclass
+class OthelloGame:
+    """Stateful controller for an Othello match."""
+
+    board: Board = field(default_factory=Board)
+    current_player: str = BLACK
+    history: List[MoveRecord] = field(default_factory=list)
+    finished: bool = False
+    winner: Optional[str] = None
+
+    def valid_moves(self) -> List[Move]:
+        return self.board.valid_moves(self.current_player)
+
+    def play_turn(self, move: Optional[Move]) -> None:
+        """Play a move for the current player.
+
+        Pass ``None`` as ``move`` to indicate a voluntary pass. The method
+        raises :class:`InvalidMoveError` if the player still has legal moves.
+        """
+
+        if self.finished:
+            raise RuntimeError("The game is already finished.")
+
+        player = self.current_player
+
+        if move is None:
+            if self.board.has_any_valid_move(player):
+                raise InvalidMoveError("Cannot pass while moves are available.")
+            self.history.append(MoveRecord(player=player, position=None, flipped=0))
+        else:
+            row, col = move
+            flipped = self.board.apply_move(row, col, player)
+            self.history.append(MoveRecord(player=player, position=move, flipped=flipped))
+
+        self._advance_turn(player)
+
+    def _advance_turn(self, just_played: str) -> None:
+        other = opponent(just_played)
+
+        if self.board.is_full():
+            self._finish_game()
+            return
+
+        if self.board.has_any_valid_move(other):
+            self.current_player = other
+            return
+
+        if self.board.has_any_valid_move(just_played):
+            # The opponent must pass automatically. Record it for completeness.
+            self.history.append(MoveRecord(player=other, position=None, flipped=0))
+            self.current_player = just_played
+            return
+
+        # No moves available for either player.
+        self._finish_game()
+
+    def _finish_game(self) -> None:
+        self.finished = True
+        scores = self.board.score()
+        self.winner = _winner_from_scores(scores)
+
+    def game_result(self) -> str:
+        scores = self.board.score()
+        if self.winner == BLACK:
+            return f"Black wins {scores[BLACK]} - {scores[WHITE]}"
+        if self.winner == WHITE:
+            return f"White wins {scores[WHITE]} - {scores[BLACK]}"
+        return f"Draw {scores[BLACK]} - {scores[WHITE]}"
+
+
+def format_move(move: Optional[Move]) -> str:
+    if move is None:
+        return "pass"
+    row, col = move
+    return f"{chr(ord('a') + col)}{row + 1}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+# Ensure the project root (containing the ``othello`` package) is importable when running tests.
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_board.py
+++ b/tests/test_board.py
@@ -1,0 +1,65 @@
+import pytest
+
+from othello.board import BLACK, WHITE, Board, EMPTY, InvalidMoveError
+
+
+def test_initial_board_setup():
+    board = Board()
+    assert board.get(3, 3) == WHITE
+    assert board.get(3, 4) == BLACK
+    assert board.get(4, 3) == BLACK
+    assert board.get(4, 4) == WHITE
+
+    scores = board.score()
+    assert scores[BLACK] == 2
+    assert scores[WHITE] == 2
+    assert scores[EMPTY] == board.size * board.size - 4
+
+
+def test_initial_valid_moves_for_black():
+    board = Board()
+    moves = sorted(board.valid_moves(BLACK))
+    assert moves == [(2, 3), (3, 2), (4, 5), (5, 4)]
+
+
+def test_initial_valid_moves_for_white():
+    board = Board()
+    moves = sorted(board.valid_moves(WHITE))
+    assert moves == [(2, 4), (3, 5), (4, 2), (5, 3)]
+
+
+def test_apply_move_flips_discs():
+    board = Board()
+    flipped = board.apply_move(2, 3, BLACK)
+    assert flipped == 1
+    assert board.get(2, 3) == BLACK
+    assert board.get(3, 3) == BLACK
+
+
+def test_invalid_move_raises():
+    board = Board()
+    with pytest.raises(InvalidMoveError):
+        board.apply_move(0, 0, BLACK)
+
+
+def test_has_any_valid_move():
+    board = Board()
+    assert board.has_any_valid_move(BLACK)
+    assert board.has_any_valid_move(WHITE)
+
+    for row in range(board.size):
+        for col in range(board.size):
+            board._grid[row][col] = BLACK
+    board._grid[3][3] = WHITE
+    board._grid[3][4] = EMPTY
+
+    assert board.has_any_valid_move(BLACK)
+    assert not board.has_any_valid_move(WHITE)
+
+
+def test_clone_creates_independent_board():
+    board = Board()
+    clone = board.clone()
+    clone.apply_move(2, 3, BLACK)
+    assert board.get(2, 3) == EMPTY
+    assert clone.get(2, 3) == BLACK

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -1,0 +1,61 @@
+import pytest
+
+from othello.board import BLACK, WHITE, EMPTY, InvalidMoveError
+from othello.game import OthelloGame
+
+
+def test_switch_turns_after_regular_move():
+    game = OthelloGame()
+    move = sorted(game.valid_moves())[0]
+    game.play_turn(move)
+    assert game.current_player == WHITE
+    assert game.history[-1].position == move
+
+
+def test_cannot_pass_when_moves_exist():
+    game = OthelloGame()
+    with pytest.raises(InvalidMoveError):
+        game.play_turn(None)
+
+
+def test_forced_pass_is_recorded():
+    game = OthelloGame()
+    board = game.board
+    for row in range(board.size):
+        for col in range(board.size):
+            board._grid[row][col] = BLACK
+    board._grid[4][5] = WHITE
+    board._grid[5][3] = WHITE
+    board._grid[5][4] = EMPTY
+    board._grid[5][5] = EMPTY
+
+    game.current_player = BLACK
+    game.history.clear()
+
+    move = (5, 5)
+    game.play_turn(move)
+
+    assert game.current_player == BLACK
+    assert len(game.history) == 2
+    assert game.history[-1].position is None
+    assert game.history[-1].player == WHITE
+
+
+def test_game_finishes_when_board_full():
+    game = OthelloGame()
+    board = game.board
+    for row in range(board.size):
+        for col in range(board.size):
+            board._grid[row][col] = BLACK
+    board._grid[0][0] = WHITE
+    board._grid[0][1] = EMPTY
+    board._grid[0][2] = BLACK
+    board._grid[0][3] = WHITE
+
+    game.current_player = WHITE
+    game.finished = False
+    game.history.clear()
+
+    game.play_turn((0, 1))
+    assert game.finished
+    assert game.winner in {BLACK, WHITE, None}


### PR DESCRIPTION
## Summary
- add a simple Othello package with board logic, AI opponent, and CLI gameplay
- include pytest-based coverage for board operations and game flow
- document usage instructions and ignore Python bytecode artifacts

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce0cf3ca98832c9473e27f7976b7a6